### PR TITLE
prevent NullPointerException on init

### DIFF
--- a/moa/src/main/java/moa/classifiers/meta/AdaptiveRandomForestRegressor.java
+++ b/moa/src/main/java/moa/classifiers/meta/AdaptiveRandomForestRegressor.java
@@ -156,6 +156,10 @@ public class AdaptiveRandomForestRegressor extends AbstractClassifier implements
     }
 
     protected void initEnsemble(Instance instance) {
+        // Check if prepareForUse() has been called
+        if(this.config == null) {
+            prepareForUse();
+        }
         // Init the ensemble.
         int ensembleSize = this.ensembleSizeOption.getValue();
         this.ensemble = new ARFFIMTDDBaseLearner[ensembleSize];


### PR DESCRIPTION
Currently, the Regressor crashes, when prepareForUse() has not been called before trainOnInstance() gets called.

This might be considered a user error, but it took me some time to figure out, why I was getting the NullPointerException. To prevent other users from experiencing this issue, I added a check to see if prepareForUse() has been called. If it has not, i simply call it myself.